### PR TITLE
Add time filtering of JSON values

### DIFF
--- a/synthea_upload.php
+++ b/synthea_upload.php
@@ -70,6 +70,7 @@
     <button id="timeline_date_update">Update</button -->
     <div id="timeCtl"></div>
     <button id="timeline_date_reset">Reset</button>
+    <img id="loadWheel" title="Loading" src="./images/loading-big.gif" style="display: none;"/>
     <div id="patInfoPlaceholder"/>
   </div>
 
@@ -166,8 +167,9 @@ $("#timeline_date_update").click( function() {
 */
 
 $("#timeline_date_reset").click( function() {
+  $("#loadWheel").show()
   d3.select('#legend_placeholder').selectAll("svg").selectAll("*").attr("class","")
-  resetMenuFile(currentJSON,"","",Object.keys(visitDict))
+  resetMenuFile(currentJSON.entry,"","",Object.keys(visitDict))
   createLegend();
 })
 
@@ -248,18 +250,20 @@ function summary_onClick(d) {
 
 function findStartDate(d) {
   var startDate=''
-  var dateKeys = [visitDict[d.resourceType]["sd"]]
-  if (typeof visitDict[d.resourceType]["sd"] == 'object') {
-    dateKeys = visitDict[d.resourceType]["sd"];
-  }
-  dateKeys.forEach(function(dateKey) {
-  if (Object.keys(d).indexOf(dateKey) != -1) {
-      startDate = d[dateKey]
-      if (typeof d[dateKey] == 'object') {
-         startDate = d[dateKey]['start'];
-      }
+  if( Object.keys(visitDict).indexOf(d.resourceType) !== -1) {
+    var dateKeys = [visitDict[d.resourceType]["sd"]]
+    if (typeof visitDict[d.resourceType]["sd"] == 'object') {
+      dateKeys = visitDict[d.resourceType]["sd"];
     }
-  })
+    dateKeys.forEach(function(dateKey) {
+    if (Object.keys(d).indexOf(dateKey) != -1) {
+        startDate = d[dateKey]
+        if (typeof d[dateKey] == 'object') {
+           startDate = d[dateKey]['start'];
+        }
+      }
+    })
+  }
   return startDate
 }
 function findStopDate(d) {
@@ -317,9 +321,10 @@ function findDescription(d) {
   return description;
 }
   d3.select("#vivSelect").on("change", function(){
+    $("#loadWheel").show()
     d3.json(d3.select('#vivSelect').property('value'), function(json) {
         currentJSON=json;
-        resetMenuFile(json,"","", Object.keys(visitDict))
+        resetMenuFile(json.entry,"","", Object.keys(visitDict))
         createLegend();
     });
   });
@@ -342,7 +347,7 @@ function resetMenuFile(json,startVal,stopVal,filterList) {
     */
     var ptInfoArray = [];
     dateArray = [];
-    json["entry"].forEach(function (val, indx) {
+    json.forEach(function (val, indx) {
       if (filterList.indexOf(val["resource"]['resourceType']) != -1) {
         var occurDate = findStartDate(val['resource'])
         dateArray.push(occurDate)
@@ -520,6 +525,7 @@ function resetMenuFile(json,startVal,stopVal,filterList) {
       .on("mouseover", rect_onMouseOver)
       .on("mouseout", rect_onMouseOut)
       .on("click", rect_onClick);
+    $("#loadWheel").hide()
 };
 
 function findLastObjects(xPos) {
@@ -633,10 +639,10 @@ function createLegend() {
         d3.select('#legend_placeholder').selectAll('rect').attr("fill", function(element) { return visitDict[element].color});
         shownTypes= Object.keys(visitDict)
       }
-      resetMenuFile(currentJSON,
-                $("#timeline_date_start")[0].value,
-                $("#timeline_date_stop")[0].value,
-               shownTypes)
+      resetMenuFile(currentJSON.entry,
+                    brush.extent()[0],
+                    brush.extent()[1],
+                   shownTypes)
     });
   legend.append("text")
     .text(function(d) { return(d) })
@@ -660,7 +666,7 @@ function createLegend() {
       var brush = d3.svg.brush()
         .x(ctrlX)
         .extent([new Date(start), new Date(stop)])
-        .on("brush", ctlZoomFunc);
+        .on("brushend", ctlZoomFunc);
       function ctlZoomFunc() {
           var value = brush.extent()[0];
           shownTypes = d3.select('#legend_placeholder').selectAll(".active").data()
@@ -674,7 +680,9 @@ function createLegend() {
                   .style("top", (d3.event.sourceEvent.pageY - 0) + "px")
                   .style("opacity", ".9");
           d3.select(".extent").attr("height","7px").style("fill","steelblue")
-          resetMenuFile(currentJSON,
+          var filteredObjs = currentJSON.entry.filter(entry =>  (entry  .resourceType == "Condition") || ((brush.extent()[0] <= new Date(findStartDate(entry.resource))) &&
+                                                                (new Date(findStartDate(entry.resource)) < brush.extent()[1])))
+          resetMenuFile(filteredObjs,
                     brush.extent()[0],
                     brush.extent()[1],
                    shownTypes)
@@ -725,10 +733,10 @@ try {
         $jsonText =  '""';
       echo $jsonText;
       ?>;
-    resetMenuFile(json,start,stop, Object.keys(visitDict))
+    resetMenuFile(json.entry,start,stop, Object.keys(visitDict))
     createLegend()
     currentJSON=json
-} catch (error) {console.log(error)
+} catch (error) {    $("#loadWheel").hide()
 }
     </script>
   </body>


### PR DESCRIPTION
To eliminate the need to cycle over every instance of data in the
patient object, filter out the JSON entries based upon the start date.
Always pass Condition objects through so that long running conditions
are not left off the display.