### PR TITLE
Make right-click function use "findStatus"

### DIFF
--- a/synthea_upload.php
+++ b/synthea_upload.php
@@ -609,7 +609,7 @@ function findLastObjects(xPos) {
       lastObjectsPretty[obj] = ''
       lastObjects[obj].forEach( function (entryObj, indx) {
         var entry = d3.select(entryObj)[0][0];
-        var header1Text = "</br>Status: " +  entry.__data__[visitDict[entry.__data__.resourceType].status] +
+        var header1Text = "</br>Status: " +  findStatus(entry.__data__) +
                       "</br>Description: " + findDescription(entry.__data__) +
                       "</br>Date: " + findStartDate(entry.__data__) +"</br></br>";
         lastObjectsPretty[obj] += header1Text;


### PR DESCRIPTION
Ensure that the gathering of last objects, used when right-clicking on
the screen uses the same findStatus function as the tooltip.  This will
prevent the status of certain objects from being marked as '[Object
object]'