### PR TITLE
Fix array sorting

### DIFF
--- a/synthea_upload.php
+++ b/synthea_upload.php
@@ -389,8 +389,8 @@ function resetMenuFile(json,startVal,stopVal,filterList) {
           patInfo = val["resource"];
       }
     })
-
-    conditionList.sort(function(a,b) {return findStartDate(a) < findStartDate(b)})
+    ptInfoArray.sort(function(a,b) {return findStartDate(a) > findStartDate(b)?1:-1})
+    conditionList.sort(function(a,b) {return findStartDate(a) > findStartDate(b)?1:-1})
     conditionList.forEach(function(val) {
       // Increase count of conditions as each condition is read in
       // Here to observe conditions with no abatement time.


### PR DESCRIPTION
Differences between browsers can be explained by returning "false" or
"0" as part of a sort, which causes no action to be taken.

The proper set of returns, assuming "equal" is not valid, should be "1" or "-1".