### PR TITLE
Add cursor styling over object bars

### DIFF
--- a/synthea_scale.css
+++ b/synthea_scale.css
@@ -61,6 +61,10 @@ div.toolTipBody {
   fill-opacity: .125;
   shape-rendering: crispEdges;
 }
+
+.bar, .summaryBar {
+  cursor: pointer;
+}
 #timeCtl .domain {
   cursor: pointer;
 }


### PR DESCRIPTION
Add a pointer cursor styling when hovering over the data entry bars or
over the "right click" summary bar to highlight that additional
information is available via a click.